### PR TITLE
fix: pin GenVM runner hash so factory deploys to Studio

### DIFF
--- a/intelligent-contracts/IntelligentOracle.py
+++ b/intelligent-contracts/IntelligentOracle.py
@@ -1,4 +1,4 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
 
 import json
 import re

--- a/intelligent-contracts/IntelligentOracleFactory.py
+++ b/intelligent-contracts/IntelligentOracleFactory.py
@@ -1,4 +1,4 @@
-# { "Depends": "py-genlayer:test" }
+# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
 
 from genlayer import *
 import genlayer.gl as gl

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,12 +1,16 @@
 {
-  "name": "scripts",
+  "name": "intelligent-oracle-deploy",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "intelligent-oracle-deploy",
+      "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "dotenv": "^17.4.2",
-        "genlayer-js": "^1.1.7"
+        "genlayer-js": "^1.1.8"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -1880,9 +1884,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-1.1.7.tgz",
-      "integrity": "sha512-4X5AAW0k6eqP1x11F39wbfyhn3IBNlqj+gS89PuY9mBwxjaf3c9JrszVzBZ7OoYW6M5nuZ2kvCP9Dm0/rdPRkA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-1.1.8.tgz",
+      "integrity": "sha512-qlqh8oqR9Ad7FVbIdqIrHfsMPLLJ24ZRHUZ2LGMpw6DX5ySjrEWdV1X93bVIHO44cu9CLGdx8m2ubkPv78/RLg==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "dotenv": "^17.4.2",
-    "genlayer-js": "^1.1.7"
+    "genlayer-js": "^1.1.8"
   },
   "scripts": {
     "deploy": "tsx deploy.ts"


### PR DESCRIPTION
## Summary
- Studio stopped resolving the `py-genlayer:test` runner alias — every factory deploy was rejected at bootstrap with `invalid_contract` (validators agreed on the rejection, empty contract stderr/stdout).
- Switched both `IntelligentOracle.py` and `IntelligentOracleFactory.py` `Depends` headers to the pinned content-addressed runner hash used by Studio's own reference contracts (`faucet.py`, `genvm_smoke_v1.py`).
- Bumped `scripts/` `genlayer-js` from 1.1.7 → 1.1.8 (incidental; ruled out as the cause but kept current).

## Test plan
- [x] `npm run deploy` from `scripts/` succeeds against `https://studio.genlayer.com/api`; verify call returns `0 markets registered`.
- [ ] Wire the resulting `NEXT_PUBLIC_ORACLE_FACTORY_ADDRESS` into the deployed app env and create one market end-to-end.