### PR TITLE
chore: update factory address in oracle-meta.json

### DIFF
--- a/public/oracle-meta.json
+++ b/public/oracle-meta.json
@@ -1,6 +1,6 @@
 {
-  "factoryAddress": "0x008A06De96d57A6dc4a83CF428E66E08dbd73e13",
+  "factoryAddress": "0x9d0D02daC114940e1a277E5FA2780DA862dA93F8",
   "rpcUrl": "https://studio.genlayer.com/api",
   "chain": "studionet",
-  "updatedAt": "2026-05-19"
+  "updatedAt": "2026-05-20"
 }


### PR DESCRIPTION
## Summary
- Update `factoryAddress` in `public/oracle-meta.json` to `0x9d0D02daC114940e1a277E5FA2780DA862dA93F8` and bump `updatedAt` to `2026-05-20`.

## Test plan
- [ ] Confirm `https://intelligentoracle.com/oracle-meta.json` serves the new factory after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated oracle metadata configuration with revised factory address and timestamp information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/intelligent-oracle/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->