### PR TITLE
docs: address external agent feedback on skill.md

### DIFF
--- a/public/skill.md
+++ b/public/skill.md
@@ -13,7 +13,8 @@ An Intelligent Oracle is a GenLayer prediction-market contract whose outcome is 
 2. **Validate** — confirm the config matches the strict schema below.
 3. **Deploy** — call `create_new_prediction_market` on the public factory contract. This is the parent transaction.
 4. **Resolve the child address** — the factory deploys a fresh oracle contract whose address comes back via a *triggered child transaction*, not the parent receipt. You must poll for the child tx.
-5. **Check later** — read `get_status()` on the oracle address. When status is `"Resolved"` or `"Error"`, settlement is final.
+5. **Verify** — read `get_dict()` on the new oracle address immediately. Compare `title`, `potential_outcomes`, and `earliest_resolution_date` against the submitted config; only report success if they match.
+6. **Monitor** — read `get_status()` periodically. When status is `"Resolved"` or `"Error"`, settlement is final.
 
 ## Network and factory address
 
@@ -79,7 +80,7 @@ This is the same prompt the hosted assistant runs on. Follow it verbatim — the
 - **Date-in-question handling.** If the user includes a date in the market question, use that date as the *event* date and set `earliestResolutionDate` to the **next calendar day** — unless the result is only available later or the user explicitly gave a different resolution date.
 - **Treat user specifics as accepted.** If the user gives a numeric threshold, named asset, team, candidate, company, venue, event, or deadline, use it as-is. Don't second-guess.
 - **Binary outcomes only.** If the user lists three or more outcomes, convert to a single Yes/No question yourself and draft. Only ask if the conversion is genuinely ambiguous.
-- **Never invent a source.** If the user supplies a specific source domain or URL, use it. Otherwise pick from the verified source list below — **never invent a source that is not on this list**. The live catalog at `https://gym.genlayer.foundation/api/benchmarks/sources-bench/sources` is authoritative; if it marks a host as `BLOCKED` or `REROUTE`, follow the catalog over the editorial defaults.
+- **Never invent a source.** If the user supplies a specific source domain or URL, use it. Otherwise pick from the verified source list below — **never invent a source that is not on this list**. The live catalog at `https://gym.genlayer.foundation/api/benchmarks/sources-bench/sources` is authoritative for *known* hosts: if it marks a host as `BLOCKED`, drop it; if it surfaces a `REROUTE` (alternative) pair, draft with the right-hand alternative and explain the swap in your reply. **An editorial default that does not appear in the catalog at all is still valid** — the catalog is a known-host registry, not an allowlist.
 - **Refinement requests are commitments, not questions.** *"Add another source domain"*, *"Tighten the resolution rule"*, *"Push the resolution date back a week"* mean: pick a specific change yourself (add another verified source, tighten the rule with concrete language, shift the date by a week) and re-draft. Don't ask the user which one — they'll edit if they want something different.
 - **Date math against today.** Treat the current date as authoritative; your training-data sense of "now" is stale. Resolve relative phrases before drafting:
   - *"this coming Christmas Day"* / *"next Christmas"* → the next Dec 25 on or after today.
@@ -87,6 +88,7 @@ This is the same prompt the hosted assistant runs on. Follow it verbatim — the
   - *"next FIFA World Cup / Olympics / election"* → the nearest future edition. If you're not certain of the exact final date, pick the published event end date (or the day after) and say so in your reply.
   - *"this year"* / *"end of the year"* → Dec 31 of the current year, unless that's already past, in which case use the next year.
   - *"in N days/weeks/months"* → add to today using calendar arithmetic.
+  - **Prepositions on a target date.** *"by X"* / *"on or before X"* / *"before end of X"* → event date = X. *"before X"* (strict) → event date = day-before-X. Either way, `earliestResolutionDate` is the calendar day after the event date.
   - Never emit an `earliestResolutionDate` on or before today.
 - **Concise, professional copy.** No emoji or decorative symbols.
 - **No infra talk.** Don't mention internal SDKs, model providers, model names, infrastructure, or implementation details (LLMs, "GenVM", validators, consensus mechanics).
@@ -130,7 +132,7 @@ Editorial defaults — use these unless the user names a specific source. For to
 - **Maritime / port activity** → `portwatch.imf.org`.
 - **Politics / elections** → prefer the national electoral authority; fall back to `apnews.com`.
 
-The live verified catalog lives at `https://gym.genlayer.foundation/api/benchmarks/sources-bench/sources`. If that catalog marks a host as `BLOCKED` or `REROUTE`, follow the catalog over this list.
+The live verified catalog lives at `https://gym.genlayer.foundation/api/benchmarks/sources-bench/sources`. If it marks a host as `BLOCKED`, drop it. If it surfaces a `REROUTE` pair, swap to the alternative. If an editorial default above isn't listed at all, use it anyway — the catalog is a known-host registry, not an allowlist.
 
 ## Three worked examples
 
@@ -217,8 +219,9 @@ import { TransactionStatus } from "genlayer-js/types";
 const client = createClient({
   chain: studionet,
   endpoint: "https://studio.genlayer.com/api",
-  // Node: account = createAccount(process.env.PRIVATE_KEY)
-  // Browser (wallet-signed): account = walletAddress, provider = injected provider
+  // Node: createAccount(process.env.PRIVATE_KEY). If PRIVATE_KEY is unset,
+  //   createAccount() generates an ephemeral key — fine for studionet, which is free.
+  // Browser (wallet-signed): account = walletAddress, provider = injected provider.
   account: createAccount(process.env.PRIVATE_KEY),
 });
 
@@ -259,7 +262,19 @@ const childReceipt = await client.waitForTransactionReceipt({
 const oracleAddress =
   childReceipt.txDataDecoded?.contractAddress ??
   childReceipt.data?.contract_address;
+
+// Verify deployment immediately — confirm the factory wrote what you submitted
+// before reporting success to the user.
+const deployed = await client.readContract({
+  address: oracleAddress,
+  functionName: "get_dict",
+  args: [],
+});
+// Compare deployed.title, deployed.potential_outcomes, and
+// deployed.earliest_resolution_date against your config.
 ```
+
+Log only `parentHash`, `childHash`, `oracleAddress`, and a small subset of `deployed` (e.g. `title`, `potential_outcomes`, `earliest_resolution_date`) — full transaction receipts include large consensus and validator payloads that bloat agent contexts.
 
 ### Raw JSON-RPC (non-JS agents)
 


### PR DESCRIPTION
## Summary

Triage of seven feedback points from an external AI agent that used the published Intelligent Oracle skill (`public/skill.md`) to draft, deploy, and verify a market end-to-end. Five points resulted in skill edits in this PR; one was rejected (full standalone `.mjs` script would duplicate the existing snippet and `scripts/deploy.ts`); one is operational (the apex domain `intelligentoracle.com` currently 404s on `/oracle-meta.json` and `/skill.md` — file lives in `public/`, so this is a Vercel project/domain-mapping fix outside this PR).

## Changes (all in `public/skill.md`)

- **Source catalog precedence** — clarify in both mentions that the gym catalog is a known-host registry, not an allowlist; editorial defaults absent from it are still valid, only `BLOCKED` / `REROUTE` override them.
- **Date prepositions** — add a bullet mapping *"by X"* / *"on or before X"* / *"before end of X"* vs. strict *"before X"* onto the event date.
- **Ephemeral keys** — snippet comments now explain that an unset `PRIVATE_KEY` lets `createAccount()` generate an ephemeral key, which is fine for free studionet.
- **Verify step** — split workflow step 5 into *Verify* (immediate `get_dict()` comparison) and *Monitor* (poll `get_status()` later); append the `get_dict()` read to the genlayer-js snippet.
- **Logging guidance** — one-line warning to log only `parentHash` / `childHash` / `oracleAddress` / minimal `deployed` subset, since receipts are bulky.

## Test plan

- [ ] Skim rendered diff on GitHub to confirm the markdown structure is intact (headings, fenced blocks, lists).
- [ ] After landing + deploying, fetch `https://intelligentoracle.com/skill.md` and confirm the new content is live (depends on the separate domain-mapping fix).
- [ ] Re-run an external agent against the same prompt the feedback came from; verify it (a) keeps `espn.com` for basketball without second-guessing, (b) reads `get_dict()` immediately after deploy, (c) logs only the four named fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated oracle workflow guidance with enhanced verification steps
  * Clarified instructions for source handling, date computation, and field validation
  * Added deployment verification examples and account/key handling documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/intelligent-oracle/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->