### PR TITLE
fix: keep assistant drafts from getting stuck

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "use-stick-to-bottom": "^1.1.4",
-    "viem": "2.47.12",
+    "viem": "2.48.11",
     "wagmi": "^2.19.5",
     "zod": "^4.4.3"
   },

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -69,6 +69,16 @@ export async function POST(request: Request) {
     model: openrouter.chat(model),
     system: buildInitialPrompt({ sourcesCatalogBlock }),
     messages: await convertToModelMessages(body.messages),
+    maxOutputTokens: 1800,
+    providerOptions: {
+      openrouter: {
+        reasoning: {
+          effort: "minimal",
+          exclude: true,
+        },
+      },
+    },
+    toolChoice: { type: "tool", toolName: "proposeOracleConfig" },
     tools: {
       proposeOracleConfig: tool({
         description: "Validate and present the complete oracle configuration.",

--- a/src/lib/oracle-config.test.ts
+++ b/src/lib/oracle-config.test.ts
@@ -37,14 +37,27 @@ describe("oracle config validation", () => {
     ]);
   });
 
-  it("requires exactly one source strategy", () => {
+  it("requires exactly one source strategy in strict validation", () => {
+    const output = parseOracleConfig({
+      ...validConfig,
+      resolutionURLs: ["https://league.example/result"],
+    });
+
+    expect(output.success).toBe(false);
+    if (output.success) return;
+    expect(output.error.issues.map((issue) => issue.message).join(" ")).toContain("not both");
+  });
+
+  it("normalizes AI drafts that include domains and URLs by keeping domains", () => {
     const output = evaluateOracleConfig({
       ...validConfig,
       resolutionURLs: ["https://league.example/result"],
     });
 
-    expect(output.status).toBe("invalid");
-    expect(output.issues.join(" ")).toContain("not both");
+    expect(output.status).toBe("valid");
+    if (output.status !== "valid") return;
+    expect(output.config.resolutionURLs).toEqual([]);
+    expect(output.config.dataSourceDomains).toEqual(validConfig.dataSourceDomains);
   });
 
   it("rejects incomplete outcomes and invalid dates", () => {
@@ -99,6 +112,37 @@ describe("oracle config validation", () => {
 
     expect(output.status).toBe("invalid");
     expect(output.issues.join(" ")).toContain("after the market event date");
+  });
+
+  it("does not treat archive or settlement deadlines as market event dates", () => {
+    const output = evaluateOracleConfig({
+      ...validConfig,
+      title: "Will New York City record measurable snowfall on 2099-12-25?",
+      description: "Resolve whether Central Park records measurable snowfall on 2099-12-25.",
+      rules: [
+        "Use the measurement reported for calendar date 2099-12-25 local time.",
+        "If agencies revise their totals, use the final archived record as published by 2100-01-02 UTC to settle this market.",
+      ],
+      earliestResolutionDate: "2099-12-26",
+    });
+
+    expect(output.status).toBe("valid");
+  });
+
+  it("does not treat pushed-back resolution dates as market event dates", () => {
+    const output = evaluateOracleConfig({
+      ...validConfig,
+      title: "Will ChatGPT be the #1 free iPhone app in the US App Store at 2099-06-30?",
+      description: "Resolve whether ChatGPT is ranked #1 on the US App Store free iPhone chart on 2099-06-30.",
+      rules: [
+        "Use the official Apple App Store chart for 2099-06-30.",
+        "If the chart is unavailable, use the earliest subsequent date with a published chart by 2099-07-08.",
+      ],
+      dataSourceDomains: ["apps.apple.com"],
+      earliestResolutionDate: "2099-07-08",
+    });
+
+    expect(output.status).toBe("valid");
   });
 
   it("normalizes source domains before deployment", () => {

--- a/src/lib/oracle-config.ts
+++ b/src/lib/oracle-config.ts
@@ -1,6 +1,6 @@
 import { z, type ZodError } from "zod";
 import { normalizeSourceDomain } from "@/lib/evidence-url";
-import { isIsoDateOnly, latestIsoDateFromText, utcDateOnly } from "@/lib/resolution-date";
+import { isIsoDateOnly, latestMarketEventIsoDateFromText, utcDateOnly } from "@/lib/resolution-date";
 
 const optionalTrimmedString = z.string().trim().optional();
 
@@ -55,7 +55,7 @@ export const oracleConfigSchema = z.object({
     });
   }
 
-  const latestEventDate = latestIsoDateFromText([
+  const latestEventDate = latestMarketEventIsoDateFromText([
     config.title,
     config.description,
     ...config.rules,
@@ -101,7 +101,7 @@ export const oracleConfigDraftSchema = z.object({
   }
 
   const earliestResolutionDate = config.earliestResolutionDate?.trim();
-  const latestEventDate = latestIsoDateFromText([
+  const latestEventDate = latestMarketEventIsoDateFromText([
     config.title,
     config.description,
     ...(config.rules ?? []),
@@ -130,7 +130,9 @@ export function parseOracleDraft(input: unknown) {
 }
 
 export function evaluateOracleConfig(input: unknown) {
-  const parsed = parseOracleConfig(input);
+  const parsedCandidate = oracleConfigCandidateSchema.safeParse(input);
+  const candidate = parsedCandidate.success ? normalizeAiCandidate(parsedCandidate.data) : input;
+  const parsed = parseOracleConfig(candidate);
   if (parsed.success) {
     return {
       status: "valid" as const,
@@ -143,6 +145,18 @@ export function evaluateOracleConfig(input: unknown) {
     status: "invalid" as const,
     config: undefined,
     issues: parsed.error.issues.map(formatIssue),
+  };
+}
+
+function normalizeAiCandidate(candidate: z.infer<typeof oracleConfigCandidateSchema>) {
+  const hasDomains = (candidate.dataSourceDomains ?? []).some((value) => value.trim());
+  const hasResolutionURLs = (candidate.resolutionURLs ?? []).some((value) => value.trim());
+
+  if (!hasDomains || !hasResolutionURLs) return candidate;
+
+  return {
+    ...candidate,
+    resolutionURLs: [],
   };
 }
 

--- a/src/lib/resolution-date.test.ts
+++ b/src/lib/resolution-date.test.ts
@@ -4,6 +4,7 @@ import {
   getResolutionUnlockDate,
   isResolutionLocked,
   latestIsoDateFromText,
+  latestMarketEventIsoDateFromText,
   utcDateOnly,
 } from "@/lib/resolution-date";
 
@@ -47,6 +48,20 @@ describe("date extraction", () => {
 
   it("finds the latest explicit ISO date from market text", () => {
     expect(latestIsoDateFromText(["First 2026-06-30", "Then 2026-07-15"])).toBe("2026-07-15");
+  });
+
+  it("ignores settlement and archive dates when extracting market event dates", () => {
+    expect(latestMarketEventIsoDateFromText([
+      "Use the measurement reported for calendar date 2026-12-25 local time.",
+      "Use the final archived record as published by 2027-01-02 UTC to settle this market.",
+    ])).toBe("2026-12-25");
+  });
+
+  it("ignores resolution-date guidance when extracting market event dates", () => {
+    expect(latestMarketEventIsoDateFromText([
+      "Will ChatGPT be the #1 free iPhone app on the US App Store at 2026-06-30?",
+      "If the chart is unavailable, use the earliest subsequent date with a published chart by 2026-07-08.",
+    ])).toBe("2026-06-30");
   });
 
   it("uses the later of earliest resolution and day-after-event", () => {

--- a/src/lib/resolution-date.ts
+++ b/src/lib/resolution-date.ts
@@ -32,6 +32,31 @@ export function latestIsoDateFromText(values: Array<string | null | undefined>):
   return latest;
 }
 
+const NON_EVENT_DATE_SEGMENT =
+  /\b(archive|archived|deadline|earliest|published|posting|resolution|revised|revision|settle|settled|settlement|subsequent)\b/i;
+
+function textSegments(value: string): string[] {
+  return value
+    .split(/(?<=[.!?])\s+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+export function latestMarketEventIsoDateFromText(values: Array<string | null | undefined>): string | undefined {
+  let latest: string | undefined;
+
+  for (const value of values) {
+    if (!value) continue;
+    for (const segment of textSegments(value)) {
+      if (NON_EVENT_DATE_SEGMENT.test(segment)) continue;
+      const candidate = latestIsoDateFromText([segment]);
+      if (candidate && (!latest || candidate > latest)) latest = candidate;
+    }
+  }
+
+  return latest;
+}
+
 export function getResolutionUnlockDate({
   earliestResolutionDate,
   eventDateTexts = [],


### PR DESCRIPTION
Fixes the assistant draft flow so OpenRouter reasoning output no longer blocks the right panel from receiving a draft. Normalizes AI source conflicts by keeping domains when a tool call includes both domains and URLs, while keeping strict validation for manual configs. Tightens event-date extraction so archive, settlement, and pushed-back resolution dates are not mistaken for market event dates. Also updates viem to match the current Privy peer dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market event date extraction capability for oracle configurations.

* **Bug Fixes**
  * Enhanced oracle configuration validation to prevent conflicting strategy settings.

* **Chores**
  * Updated viem dependency to version 2.48.11.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/intelligent-oracle/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->